### PR TITLE
fix(nonce): request nonce from rpc on transfer

### DIFF
--- a/internal/chain/transaction.go
+++ b/internal/chain/transaction.go
@@ -66,10 +66,18 @@ func (b *TxBuild) Sender() common.Address {
 func (b *TxBuild) Transfer(ctx context.Context, to string, value *big.Int) (common.Hash, error) {
 	gasLimit := uint64(21000)
 	toAddress := common.HexToAddress(to)
-	nonce := b.getAndIncrementNonce()
 
 	var err error
 	var unsignedTx *types.Transaction
+
+	nonce, err := b.client.PendingNonceAt(ctx, b.Sender())
+	if err != nil {
+		log.WithFields(log.Fields{
+			"address": b.Sender(),
+			"error":   err,
+		}).Error("failed to get nonce")
+		return common.Hash{}, err
+	}
 
 	if b.supportsEIP1559 {
 		unsignedTx, err = b.buildEIP1559Tx(ctx, &toAddress, value, gasLimit, nonce)


### PR DESCRIPTION
Request nonce from rpc on transfer to avoid any tx's getting stuck in tx pool.